### PR TITLE
Use walletd instead of simplewallet for payments

### DIFF
--- a/config.json
+++ b/config.json
@@ -131,7 +131,7 @@
         },
         "wallet": {
             "checkInterval": 60,
-            "rpcMethod": "getbalance"
+            "rpcMethod": "getBalance"
         }
     },
 

--- a/config.json
+++ b/config.json
@@ -110,12 +110,12 @@
 
     "daemon": {
         "host": "127.0.0.1",
-        "port": 42081
+        "port": 11898
     },
 
     "wallet": {
         "host": "127.0.0.1",
-        "port": 8082,
+        "port": 8070,
         "password": "<replace with rpc password>"
     },
 

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -71,6 +71,24 @@ function runInterval(){
             }
 
             var transferCommands = [];
+			var totalFee = (config.coinUnits/10) * (Object.keys(payments).length); // Taxe de transaction calculée par rapport au nombre de paiement.
+            for (var i = 0; i < transferCommandsLength; i++){
+                transferCommands.push({
+					amount: 0,
+					redis: [],
+					rpc: {
+						addresses: [],
+						transfers: [],
+						fee: totalFee,
+                        // should this be config.payments.mixin?
+						anonymity: 1,
+						changeAddress: config.poolServer.poolAddress,
+						paymentId:'',
+						unlock_time: 0
+					}
+                });
+            }
+
             var addresses = 0;
             var commandAmount = 0;
             var commandIndex = 0;
@@ -80,19 +98,6 @@ function runInterval(){
 				if(config.payments.maxTransactionAmount && amount + commandAmount > config.payments.maxTransactionAmount) {
 		            amount = config.payments.maxTransactionAmount - commandAmount;
 	            }
-				
-				if(!transferCommands[commandIndex]) {
-					transferCommands[commandIndex] = {
-						redis: [],
-						amount : 0,
-						rpc: {
-							destinations: [],
-							fee: config.payments.transferFee,
-							mixin: config.payments.mixin,
-							unlock_time: 0
-						}
-					};
-				}
 				
                 transferCommands[commandIndex].rpc.destinations.push({amount: amount, address: worker});
                 transferCommands[commandIndex].redis.push(['hincrby', config.coin + ':workers:' + worker, 'balance', -amount]);
@@ -111,9 +116,9 @@ function runInterval(){
             var timeOffset = 0;
 
             async.filter(transferCommands, function(transferCmd, cback){
-                apiInterfaces.rpcWallet('transfer', transferCmd.rpc, function(error, result){
+                apiInterfaces.rpcWallet('sendTransaction', transferCmd.rpc, function(error, result){
                     if (error){
-                        log('error', logSystem, 'Error with send_transaction RPC request to wallet daemon %j', [error]);
+                        log('error', logSystem, 'Error with sendTransaction RPC request to wallet daemon %j', [error]);
                         log('error', logSystem, 'Payments failed to send to %j', transferCmd.rpc.destinations);
                         cback(false);
                         return;

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -71,21 +71,31 @@ function runInterval(){
             }
 
             var transferCommands = [];
-			var totalFee = (config.coinUnits/10) * (Object.keys(payments).length); // Taxe de transaction calculée par rapport au nombre de paiement.
+
+            /* This seems to be having a larger fee based on the amount of
+               payments, in practice currently any transaction which doesn't
+               exceed a transaction size of roughly 115k bytes will go
+               through with a fee of 0.1 TRTL. Pools generally will never hit
+               this cap I believe, due to them having not very fragmented
+               balances. (Payouts are regular (if needed) and will rarely be
+               comprised of many inputs as they come from the block payout).
+               Not sure how this would apply to other chains however, if we
+               want to push this upstream. This is a fee of 0.1 TRTL for
+               every payment. */
+			var totalFee = (config.coinUnits/10) * (Object.keys(payments).length);
             for (var i = 0; i < transferCommandsLength; i++){
                 transferCommands.push({
-					amount: 0,
-					redis: [],
-					rpc: {
-						addresses: [],
-						transfers: [],
-						fee: totalFee,
-                        // should this be config.payments.mixin?
-						anonymity: 1,
-						changeAddress: config.poolServer.poolAddress,
-						paymentId:'',
-						unlock_time: 0
-					}
+                    amount: 0,
+                    redis: [],
+                    rpc: {
+                        addresses: [],
+                        transfers: [],
+                        fee: totalFee,
+                        anonymity: config.payments.mixin,
+                        changeAddress: config.poolServer.poolAddress,
+                        paymentId:'',
+                        unlock_time: 0
+                    }
                 });
             }
 

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -72,17 +72,6 @@ function runInterval(){
 
             var transferCommands = [];
 
-            /* This seems to be having a larger fee based on the amount of
-               payments, in practice currently any transaction which doesn't
-               exceed a transaction size of roughly 115k bytes will go
-               through with a fee of 0.1 TRTL. Pools generally will never hit
-               this cap I believe, due to them having not very fragmented
-               balances. (Payouts are regular (if needed) and will rarely be
-               comprised of many inputs as they come from the block payout).
-               Not sure how this would apply to other chains however, if we
-               want to push this upstream. This is a fee of 0.1 TRTL for
-               every payment. */
-			var totalFee = (config.coinUnits/10) * (Object.keys(payments).length);
             for (var i = 0; i < transferCommandsLength; i++){
                 transferCommands.push({
                     amount: 0,
@@ -90,7 +79,7 @@ function runInterval(){
                     rpc: {
                         addresses: [],
                         transfers: [],
-                        fee: totalFee,
+                        fee: config.payments.transferFee,
                         anonymity: config.payments.mixin,
                         changeAddress: config.poolServer.poolAddress,
                         paymentId:'',

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -86,18 +86,14 @@ function runInterval(){
 						redis: [],
 						amount : 0,
 						rpc: {
-							addresses: [],
                         				transfers: [],
                         				fee: config.payments.transferFee,
                        					anonymity: config.payments.mixin,
-                        				changeAddress: config.poolServer.poolAddress,
-                        				paymentId:'',
-                       					unlock_time: 0
 						}
 					};
 				}
 				
-                transferCommands[commandIndex].rpc.destinations.push({amount: amount, address: worker});
+                transferCommands[commandIndex].rpc.transfers.push({amount: amount, address: worker});
                 transferCommands[commandIndex].redis.push(['hincrby', config.coin + ':workers:' + worker, 'balance', -amount]);
                 transferCommands[commandIndex].redis.push(['hincrby', config.coin + ':workers:' + worker, 'paid', amount]);
                 transferCommands[commandIndex].amount += amount;

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -117,31 +117,31 @@ function runInterval(){
                 apiInterfaces.rpcWallet('sendTransaction', transferCmd.rpc, function(error, result){
                     if (error){
                         log('error', logSystem, 'Error with sendTransaction RPC request to wallet daemon %j', [error]);
-                        log('error', logSystem, 'Payments failed to send to %j', transferCmd.rpc.destinations);
+                        log('error', logSystem, 'Payments failed to send to %j', transferCmd.rpc.transfers);
                         cback(false);
                         return;
                     }
 
                     var now = (timeOffset++) + Date.now() / 1000 | 0;
-                    var txHash = result.tx_hash;
+                    var txHash = result.transactionHash;
 
 
                     transferCmd.redis.push(['zadd', config.coin + ':payments:all', now, [
                         txHash,
                         transferCmd.amount,
                         transferCmd.rpc.fee,
-                        transferCmd.rpc.mixin,
-                        Object.keys(transferCmd.rpc.destinations).length
+                        transferCmd.rpc.anonymity,
+                        Object.keys(transferCmd.rpc.transfers).length
                     ].join(':')]);
 
 
-                    for (var i = 0; i < transferCmd.rpc.destinations.length; i++){
-                        var destination = transferCmd.rpc.destinations[i];
+                    for (var i = 0; i < transferCmd.rpc.transfers.length; i++){
+                        var destination = transferCmd.rpc.transfers[i];
                         transferCmd.redis.push(['zadd', config.coin + ':payments:' + destination.address, now, [
                             txHash,
                             destination.amount,
                             transferCmd.rpc.fee,
-                            transferCmd.rpc.mixin
+                            transferCmd.rpc.anonymity
                         ].join(':')]);
                     }
 
@@ -150,7 +150,7 @@ function runInterval(){
                     redisClient.multi(transferCmd.redis).exec(function(error, replies){
                         if (error){
                             log('error', logSystem, 'Super critical error! Payments sent yet failing to update balance in redis, double payouts likely to happen %j', [error]);
-                            log('error', logSystem, 'Double payments likely to be sent to %j', transferCmd.rpc.destinations);
+                            log('error', logSystem, 'Double payments likely to be sent to %j', transferCmd.rpc.transfers);
                             cback(false);
                             return;
                         }


### PR DESCRIPTION
Should probably push this up now simplewallet changes have been merged.

I have tested this out on a testnet pool and payments work fine.

To use, start walletd like so: 

```
./walletd -w yourwalletfile.wallet -p yourwalletpassword --rpc-password yourrpcpassword --log-level 4
```

The default port in the config is 11898, if you wish to change this you can use `--daemon-port yourport` to bind to another port in walletd.

Note that walletd uses a different wallet format than simplewallet, and it will convert your simplewallet upon creation. It should create a .backup file, but to make sure you might want to make a copy of your wallet file so you can easily revert to simplewallet api if needed.

To continue the conversation that was in the simplewallet discussion, the new version of simplewallet uses the walletgreen class instead of walletlegacy, and so the current rpc is not able to be implemented without significant changes. 

It was considered perhaps a more sensible idea to move the pool code across to walletd as it provides a more programmatic interface than current simplewallet - furthermore, any re-implementation of the simplewallet api within new simplewallet would simply be wrapping walletd calls, and so wouldn't really gain anything but more code complexity.

Of course I don't want to disrupt pools continued operation, so it was suggested that perhaps the old simplewallet be re-uploaded, perhaps renamed to pool-wallet.