### PR TITLE
Supply password for admin api request

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -162,7 +162,8 @@ function getNetworkDifficulty(callback) {
 }
 
 function getUsersHashrates(callback) {
-    apiInterfaces.pool('/miners_hashrate', function(error, data) {
+    var method = '/miners_hashrate?password=' + config.api.password;
+    apiInterfaces.pool(method, function(error, data) {
         callback(data.minersHashrate);
     });
 }


### PR DESCRIPTION
Charts fills up the logs attempting to generate a chart about miners hashrate.
It fails as that api endpoint needs a password.
Password is now supplied, no more errors.