### PR TITLE
Banning Improvements

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -336,7 +336,7 @@ Miner.prototype = {
         var stats = perIPStats[this.ip];
         validShare ? stats.validShares++ : stats.invalidShares++;
         if (stats.validShares + stats.invalidShares >= config.poolServer.banning.checkThreshold){
-            if (stats.invalidShares / stats.validShares >= config.poolServer.banning.invalidPercent / 100){
+            if (stats.invalidShares / (stats.invalidShares + stats.validShares) >= config.poolServer.banning.invalidPercent / 100) {
                 log('warn', logSystem, 'Banned %s@%s', [this.login, this.ip]);
                 bannedIPs[this.ip] = Date.now();
                 delete connectedMiners[this.id];
@@ -566,16 +566,22 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
 	    if (!noncePattern.test(params.nonce)) {
                 var minerText = miner ? (' ' + miner.login + '@' + miner.ip) : '';
                 log('warn', logSystem, 'Malformed nonce: ' + JSON.stringify(params) + ' from ' + minerText);
-                perIPStats[miner.ip] = { validShares: 0, invalidShares: 999999 };
+                if (!perIPStats[miner.ip]) {
+                    perIPStats[miner.ip] = { validShares: 0, invalidShares: 0 };
+                }
+                perIPStats[miner.ip].invalidShares += Math.floor((config.poolServer.banning.checkThreshold / 4) * (config.poolServer.banning.invalidPercent / 100) - 1);
                 miner.checkBan(false);
-                sendReply('Duplicate share');
+                sendReply('Malformed nounce');
                 return;
             }
 
             if (job.submissions.indexOf(params.nonce) !== -1){
                 var minerText = miner ? (' ' + miner.login + '@' + miner.ip) : '';
                 log('warn', logSystem, 'Duplicate share: ' + JSON.stringify(params) + ' from ' + minerText);
-                perIPStats[miner.ip] = { validShares: 0, invalidShares: 999999 };
+                if (!perIPStats[miner.ip]) {
+                    perIPStats[miner.ip] = { validShares: 0, invalidShares: 0 };
+                }
+                perIPStats[miner.ip].invalidShares += Math.floor((config.poolServer.banning.checkThreshold / 4) * (config.poolServer.banning.invalidPercent / 100) - 1);
                 miner.checkBan(false);
                 sendReply('Duplicate share');
                 return;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -569,19 +569,18 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 if (!perIPStats[miner.ip]) {
                     perIPStats[miner.ip] = { validShares: 0, invalidShares: 0 };
                 }
-                perIPStats[miner.ip].invalidShares += Math.floor((config.poolServer.banning.checkThreshold / 4) * (config.poolServer.banning.invalidPercent / 100) - 1);
+                perIPStats[miner.ip].invalidShares += Math.floor((config.poolServer.banning.checkThreshold / 4) * (config.poolServer.banning.invalidPercent / 100) -1);
                 miner.checkBan(false);
-                sendReply('Malformed nounce');
+                sendReply('Malformed nonce');
                 return;
             }
-
-            if (job.submissions.indexOf(params.nonce) !== -1){
+            else if (job.submissions.indexOf(params.nonce) !== -1){
                 var minerText = miner ? (' ' + miner.login + '@' + miner.ip) : '';
                 log('warn', logSystem, 'Duplicate share: ' + JSON.stringify(params) + ' from ' + minerText);
                 if (!perIPStats[miner.ip]) {
                     perIPStats[miner.ip] = { validShares: 0, invalidShares: 0 };
                 }
-                perIPStats[miner.ip].invalidShares += Math.floor((config.poolServer.banning.checkThreshold / 4) * (config.poolServer.banning.invalidPercent / 100) - 1);
+                perIPStats[miner.ip].invalidShares += Math.floor((config.poolServer.banning.checkThreshold / 4) * (config.poolServer.banning.invalidPercent / 100) -1);
                 miner.checkBan(false);
                 sendReply('Duplicate share');
                 return;


### PR DESCRIPTION
Following improvements:
-Duplicate shares and malformed nounce count as 25% of config.poolServer.banning.invalidPercent instead of insta-ban. Some mining software by nature produce the occasional duplicate share.
-Modified ban calculation so that config.poolServer.banning.invalidPercent is the percentage of invalid shares of config.poolServer.banning.checkThreshold that trigger a ban.