### PR TITLE
Correct requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Usage
 #### Requirements
 * Coin daemon(s) (find the coin's repo and build latest version from source)
 * simplewallet (Bytecoin/Forknote v1.1.11).  Do NOT use Forknote 2.0.0, since it's in alpha
-```
 * [Node.js](http://nodejs.org/) v0.10+ ([follow these installation instructions](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager))
 * [Redis](http://redis.io/) key-value store v2.6+ ([follow these instructions](http://redis.io/topics/quickstart))
 * libssl required for the node-multi-hashing module


### PR DESCRIPTION
Noticed the README had too many "```" in the requirements section, making it harder to parse. Fixed.