### PR TITLE
Exit if failed to start pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -183,7 +183,7 @@ function processBlockTemplate(template){
     jobRefresh(true, function(sucessful){
         if (!sucessful){
             log('error', logSystem, 'Could not start pool');
-            return;
+            exit;
         }
         startPoolServerTcp(function(successful){
 


### PR DESCRIPTION
New PR (old one was a mistake)

When bringing up the entire mining pool stack under Docker Swarm, the TurtleCoind daemon starts at the same time as all the other elements. However, TurtleCoind takes some time to be ready (syncing with the blockchain, etc), and if pool starts before daemon is ready (quite likely), it'll log an error about being unable to start, but will then just hang around being useless. I discovered this under my swarm when pool wouln't listen on its ports (i.e., 3333 etc) on first deploy, but if I killed and recreated it, it'd start listening as expected.

This change just forces the pool thread to exit (rather than return) if it's logged an error about failing to start, so that a replacement can be spawned.



