### PR TITLE
Let api run on separate host

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Explanation for each field:
     "enabled": true,
     "hashrateWindow": 600, //how many second worth of shares used to estimate hash rate
     "updateInterval": 3, //gather stats and broadcast every this many seconds
+    "host": 127.0.0.1, //if api module is running on a different host (i.e, containerized),
     "port": 8117,
     "blocks": 30, //amount of blocks to send at a time
     "payments": 30, //amount of payments to send at a time

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Explanation for each field:
     "enabled": true,
     "hashrateWindow": 600, //how many second worth of shares used to estimate hash rate
     "updateInterval": 3, //gather stats and broadcast every this many seconds
-    "host": 127.0.0.1, //if api module is running on a different host (i.e, containerized),
+    "host": "127.0.0.1", //if api module is running on a different host (i.e, containerized),
     "port": 8117,
     "blocks": 30, //amount of blocks to send at a time
     "payments": 30, //amount of payments to send at a time

--- a/config.json
+++ b/config.json
@@ -102,7 +102,7 @@
         "enabled": true,
         "hashrateWindow": 600,
         "updateInterval": 5,
-        "host": 127.0.0.1,
+        "host": "127.0.0.1",
         "port": 8117,
         "blocks": 30,
         "payments": 30,

--- a/config.json
+++ b/config.json
@@ -102,6 +102,7 @@
         "enabled": true,
         "hashrateWindow": 600,
         "updateInterval": 5,
+        "host": 127.0.0.1,
         "port": 8117,
         "blocks": 30,
         "payments": 30,

--- a/lib/apiInterfaces.js
+++ b/lib/apiInterfaces.js
@@ -90,7 +90,10 @@ module.exports = function(daemonConfig, walletConfig, poolApiConfig){
                 walletConfig.password);
         },
         pool: function(method, callback){
-            jsonHttpRequest('127.0.0.1', poolApiConfig.port, '', callback, method);
+            if (poolApiConfig.host == undefined) {
+                poolApiConfig.host = '127.0.0.1';
+            }
+            jsonHttpRequest(poolApiConfig.host, poolApiConfig.port, '', callback, method);
         },
         jsonHttpRequest: jsonHttpRequest
     }


### PR DESCRIPTION
This is a minor enhancement to support running the 5 pool modules as isolated container within docker-compose/swarm. The charts module _assumes_ the API is running on 127.0.0.1, but in docker-land that's not the case - each container has its own unique IP.

This PR simply adds the _option_ to specify an api host. If no host is specified, previous behaviour is honoured, and 127.0.0.1 is assumed.

I've tested this both with and without a host entry in the api settings under config.json, works as expected. The PR'd version is currently running (dockerized) on https://trtl.heigh-ho.funkypenguin.co.nz/, generating sexy charts.