### PR TITLE
Disable shareTrust by default

### DIFF
--- a/config.json
+++ b/config.json
@@ -58,7 +58,7 @@
       "addressSeparator": "."
     },
     "shareTrust": {
-      "enabled": true,
+      "enabled": false,
       "min": 10,
       "stepDown": 3,
       "threshold": 10,


### PR DESCRIPTION
Disable shareTrust by default as it is exploitable in it's current implementation. 