### PR TITLE
ShareTrust Improvements WIP

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -42,6 +42,7 @@ var connectedMiners = {}
 var bannedIPs = {}
 var perIPStats = {}
 
+var minerShareTrust = {ip: {}, address: {}}
 var shareTrustEnabled = config.poolServer.shareTrust && config.poolServer.shareTrust.enabled
 var shareTrustStepFloat = shareTrustEnabled ? config.poolServer.shareTrust.stepDown / 100 : 0
 var shareTrustMinFloat = shareTrustEnabled ? config.poolServer.shareTrust.min / 100 : 0
@@ -199,14 +200,6 @@ function Miner (id, login, workerName, pass, ip, startingDiff, noRetarget, pushM
   // Vardiff related variables
   this.shareTimeRing = utils.ringBuffer(16)
   this.lastShareTime = Date.now() / 1000 | 0
-
-  if (shareTrustEnabled) {
-    this.trust = {
-      threshold: config.poolServer.shareTrust.threshold,
-      probability: 1,
-      penalty: 0
-    }
-  }
 }
 Miner.prototype = {
   retarget: function (now) {
@@ -325,6 +318,49 @@ Miner.prototype = {
         stats.validShares = 0
       }
     }
+  },
+  checkTrust: function () {
+    if (!minerShareTrust.ip[this.ip]) {
+      minerShareTrust.ip[this.ip] = {
+      threshold: config.poolServer.shareTrust.threshold,
+      probability: 1,
+      penalty: 0
+      }
+    }
+    if (!minerShareTrust.address[this.login]) {
+      minerShareTrust.address[this.login] = {
+      threshold: config.poolServer.shareTrust.threshold,
+      probability: 1,
+      penalty: 0
+      }
+    }
+    var shareTrustIP = minerShareTrust.ip[this.ip]
+    var shareTrustAddress = minerShareTrust.address[this.login]
+    if ((shareTrustIP.threshold <= 0 && shareTrustIP.penalty <= 0 && Math.random() > shareTrustIP.probability) && (shareTrustAddress.threshold <= 0 && shareTrustAddress.penalty <= 0 && Math.random() > shareTrustAddress.probability)) {
+      return true;
+    }
+    return false;
+  },
+  setTrust: function (shareAccepted) {
+    var shareTrustIP = minerShareTrust.ip[this.ip]
+    var shareTrustAddress = minerShareTrust.address[this.login]
+    if (shareTrustIP && shareTrustAddress) {
+      if (shareAccepted) {
+        shareTrustIP.probability -= shareTrustStepFloat
+        if (shareTrustIP.probability < shareTrustMinFloat) { shareTrustIP.probability = shareTrustMinFloat }
+        shareTrustIP.penalty--
+        shareTrustIP.threshold--
+        shareTrustAddress.probability -= shareTrustStepFloat
+        if (shareTrustAddress.probability < shareTrustMinFloat) { shareTrustAddress.probability = shareTrustMinFloat }
+        shareTrustAddress.penalty--
+        shareTrustAddress.threshold--
+      } else {
+        shareTrustIP.probability = 1
+        shareTrustIP.penalty = config.poolServer.shareTrust.penalty
+        shareTrustAddress.probability = 1
+        shareTrustAddress.penalty = config.poolServer.shareTrust.penalty
+      }
+    }
   }
 }
 
@@ -400,7 +436,7 @@ function processShare (miner, job, blockTemplate, nonce, resultHash) {
   var hash
   var shareType
 
-  if (shareTrustEnabled && miner.trust.threshold <= 0 && miner.trust.penalty <= 0 && Math.random() > miner.trust.probability) {
+  if (shareTrustEnabled && miner.checkTrust()) {
     hash = new Buffer(resultHash, 'hex')
     shareType = 'trusted'
   } else {
@@ -576,15 +612,9 @@ function handleMinerMethod (method, params, ip, portData, sendReply, pushMessage
       miner.checkBan(shareAccepted)
 
       if (shareTrustEnabled) {
-        if (shareAccepted) {
-          miner.trust.probability -= shareTrustStepFloat
-          if (miner.trust.probability < shareTrustMinFloat) { miner.trust.probability = shareTrustMinFloat }
-          miner.trust.penalty--
-          miner.trust.threshold--
-        } else {
+        miner.setTrust(shareAccepted)
+        if (!shareAccepted) {
           log('warn', logSystem, 'Share trust broken by %s@%s', [miner.login, miner.ip])
-          miner.trust.probability = 1
-          miner.trust.penalty = config.poolServer.shareTrust.penalty
         }
       }
 


### PR DESCRIPTION
This WIP provides persistent tracking of miner sharetrust probabilities, independently by both IP and Address. Both must validate for a share to be trusted. Probabilities are persisted in memory between miner reconnects.