### PR TITLE
ShareTrust Improvements - WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,20 @@ Explanation for each field:
     /* Feature to trust share difficulties from miners which can
        significantly reduce CPU load. */
     "shareTrust": {
-        "enabled": true,
-        "min": 10, //Minimum percent probability for share hashing
-        "stepDown": 3, //Increase trust probability % this much with each valid share
-        "threshold": 10, //Amount of valid shares required before trusting begins
-        "penalty": 30 //Upon breaking trust require this many valid share before trusting
+      "enabled": false, //enable or disable the shareTrust system. shareTrust can offer significant CPU workload reduction, however does present a risk of being exploited by miners gaming the percentages of the system.
+      "maxTrustPercent": 50, //The maximum percent chance a share will be considered trusted (not fully validated) 50 means 1 of 2 shares are fully validated at random, 75 means 1 of 4 are fully validated (or 3 of 4 are trusted).
+      "probabilityStepPercent": 1, //The percent the probabality of a share is trusted increases from 0 to maxTrustPercent at a maximum rate of once per probabilityStepWindow seconds in steps of probabilityStepPercent and only on share submission.
+      "probabilityStepWindow": 30, //The probability (chance a share is considered trusted) will increase from 0 to maxTrustPercent by steps of probabilityStepPercent at a maximum rate of once every probabilityStepWindow seconds.
+      "minUntrustedShares": 50, //The minimum amount of shares that will be fully validated before shareTrust will begin.
+      "minUntrustedSeconds": 300, //The minimum amount of time in seconds shares will be fully validated before shareTrust will begin.
+      "maxTrustedDifficulty": 100000, //Shares above this difficulty will be fully validated (not trusted).
+      "maxPenaltyMultiplier": 100, //The maximum penalty multiplied against minUntrustedShares and minUntrustedSeconds.
+      "minPenaltyMultiplier": 2, //The minimum penalty multiplied against minUntrustedShares and minUntrustedSeconds.
+      "penaltyMultiplierStep": 1, //The penalty is multiplied against minUntrustedShares and minUntrustedSeconds. The penalty Steps up/down penaltyMultiplierStep a maximum of once per every penaltyStepUpWindow or penaltyStepDownWindow and only on share submission.
+      "penaltyStepUpWindow": 30, //The penalty steps up a maximum of penaltyMultiplierStep every penaltyStepUpWindow seconds and only on share submission.
+      "penaltyStepDownWindow": 120, //The penalty steps down a maximum of penaltyMultiplierStep every penaltyStepDownWindow seconds and only on share submission.
+      "maxShareWindow": 300, //Must Submit within this window or minUntrustedSeconds, minUntrustedShares and Probability are reset.
+      "maxAge": 604800 //Maximum seconds to retain dissconnected miner shareTrust data in memory.
     },
 
     /* If under low-diff share attack we can ban their IP to reduce system/network load. */

--- a/config.json
+++ b/config.json
@@ -61,7 +61,7 @@
       "enabled": false,
       "maxTrustPercent": 50,
       "probabilityStepPercent": 1,
-      "probabilityStepWindow": 30,
+      "probabilityStepWindow": 15,
       "minUntrustedShares": 50,
       "minUntrustedSeconds": 300,
       "maxTrustedDifficulty": 100000,

--- a/config.json
+++ b/config.json
@@ -61,10 +61,17 @@
       "enabled": false,
       "maxTrustPercent": 50,
       "probabilityStepPercent": 1,
-      "minUntrustedShares": 10,
+      "probabilityStepWindow": 30,
+      "minUntrustedShares": 50,
       "minUntrustedSeconds": 300,
       "maxTrustedDifficulty": 100000,
-      "penaltyMultiplier": 1
+      "maxPenaltyMultiplier": 100,
+      "minPenaltyMultiplier": 2,
+      "penaltyMultiplierStep": 1,
+      "penaltyStepUpWindow": 30,
+      "penaltyStepDownWindow": 120,
+      "maxShareWindow": 300,
+      "maxAge": 604800
     },
     "banning": {
       "enabled": true,

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -84,23 +84,33 @@ setInterval(function () {
     }
   }
 
-  if (shareTrustEnabled){
+  if (shareTrustEnabled) {
     var maxShareTrustAge = config.poolServer.shareTrust.maxAge
+    var ipTrustCount = 0
+    var addressTrustCount = 0
+
     for (ip in minerShareTrust.ip) {
       var minerShareTrustData = minerShareTrust.ip[ip]
-      if (dateNowSeconds - minerShareTrustData.lastShareSeconds > maxShareTrustAge){
+      if (dateNowSeconds - minerShareTrustData.lastShareSeconds > maxShareTrustAge) {
         delete minerShareTrust.ip[ip]
         log('info', logSystem, 'ShareTrust data removed for ip %s', [ip])
+      } else {
+        if (minerShareTrust.ip[ip].trusted) { ipTrustCount++ }
       }
     }
 
     for (address in minerShareTrust.address) {
       var minerShareTrustData = minerShareTrust.address[address]
-      if (dateNowSeconds - minerShareTrustData.lastShareSeconds > maxShareTrustAge){
-        delete minerShareTrust.ip[address]
+      if (dateNowSeconds - minerShareTrustData.lastShareSeconds > maxShareTrustAge) {
+        delete minerShareTrust.address[address]
         log('info', logSystem, 'ShareTrust data removed for address %s', [address])
+      } else {
+        if (minerShareTrust.address[address].trusted) { addressTrustCount++ }
       }
     }
+
+    log('info', logSystem, 'ShareTrust IP: Trusted: %s Total: %s', [ipTrustCount, Object.keys(minerShareTrust.ip).length])
+    log('info', logSystem, 'ShareTrust Address: Trusted: %s Total: %s', [addressTrustCount, Object.keys(minerShareTrust.address).length])
   }
 }, 30000)
 
@@ -234,7 +244,8 @@ function Miner (id, login, workerName, pass, ip, startingDiff, noRetarget, pushM
       lastShareSeconds: dateNowSeconds,
       penaltyStepUpBeginSeconds: dateNowSeconds,
       penaltyStepDownBeginSeconds: dateNowSeconds,
-      probabilityStepWindowBeginSeconds: dateNowSeconds
+      probabilityStepWindowBeginSeconds: dateNowSeconds,
+      trusted: false
       }
     }
     if (!minerShareTrust.address[this.login]) {
@@ -247,7 +258,8 @@ function Miner (id, login, workerName, pass, ip, startingDiff, noRetarget, pushM
       lastShareSeconds: dateNowSeconds,
       penaltyStepUpBeginSeconds: dateNowSeconds,
       penaltyStepDownBeginSeconds: dateNowSeconds,
-      probabilityStepWindowBeginSeconds: dateNowSeconds
+      probabilityStepWindowBeginSeconds: dateNowSeconds,
+      trusted: false
       }
     }
   }
@@ -376,13 +388,14 @@ Miner.prototype = {
     var shareTrustIP = minerShareTrust.ip[this.ip]
     var shareTrustAddress = minerShareTrust.address[this.login]
     if (shareTrustIP && shareTrustAddress) {
+      var rand = Math.random()
       var ipPastThresholds = dateNowSeconds - shareTrustIP.trustBeginSeconds > shareTrustIP.minUntrustedSeconds && shareTrustIP.untrustedShareThreshold <= 0
       var addressPastThresholds = dateNowSeconds - shareTrustAddress.trustBeginSeconds > shareTrustAddress.minUntrustedSeconds && shareTrustAddress.untrustedShareThreshold <= 0
       var inShareWindow = dateNowSeconds - shareTrustAddress.lastShareSeconds < shareTrustSettings.maxShareWindow && dateNowSeconds - shareTrustIP.lastShareSeconds < shareTrustSettings.maxShareWindow
       if (ipPastThresholds && addressPastThresholds && inShareWindow && shareTrustIP.trustProbability >= shareTrustMaxTrustPercent && shareTrustAddress.trustProbability >= shareTrustMaxTrustPercent) {
-        this.trusted = true
+        this.trusted = shareTrustIP.trusted = shareTrustAddress.trusted = true
       }
-      if ((difficulty < shareTrustSettings.maxTrustedDifficulty) && (inShareWindow) && (ipPastThresholds && Math.random() < shareTrustIP.trustProbability) && (addressPastThresholds && Math.random() < shareTrustAddress.trustProbability)) {
+      if ((difficulty < shareTrustSettings.maxTrustedDifficulty) && (inShareWindow) && (ipPastThresholds && rand < shareTrustIP.trustProbability) && (addressPastThresholds && rand < shareTrustAddress.trustProbability)) {
         return true;
       }
     }
@@ -436,7 +449,7 @@ Miner.prototype = {
         shareTrustAddress.untrustedShareThreshold = (shareTrustSettings.minUntrustedShares * shareTrustAddress.currentPenaltyMultiplier)
         shareTrustIP.minUntrustedSeconds = (shareTrustSettings.minUntrustedSeconds * shareTrustIP.currentPenaltyMultiplier)
         shareTrustAddress.minUntrustedSeconds = (shareTrustSettings.minUntrustedSeconds * shareTrustAddress.currentPenaltyMultiplier)
-        this.trusted = false
+        this.trusted = shareTrustIP.trusted = shareTrustAddress.trusted = false
       }
       shareTrustAddress.lastShareSeconds = shareTrustIP.lastShareSeconds = dateNowSeconds
     }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -83,6 +83,10 @@ setInterval(function () {
       }
     }
   }
+}, 30000)
+
+setInterval(function () {
+  var dateNowSeconds = Date.now() / 1000 | 0
 
   if (shareTrustEnabled) {
     var maxShareTrustAge = config.poolServer.shareTrust.maxAge
@@ -112,7 +116,7 @@ setInterval(function () {
     log('info', logSystem, 'ShareTrust IP: Trusted: %s Total: %s', [ipTrustCount, Object.keys(minerShareTrust.ip).length])
     log('info', logSystem, 'ShareTrust Address: Trusted: %s Total: %s', [addressTrustCount, Object.keys(minerShareTrust.address).length])
   }
-}, 30000)
+}, 300000)
 
 process.on('message', function (message) {
   switch (message.type) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -63,6 +63,7 @@ setInterval(function () {
 /* Every 30 seconds clear out timed-out miners and old bans */
 setInterval(function () {
   var now = Date.now()
+  var dateNowSeconds = now / 1000 | 0
   var timeout = config.poolServer.minerTimeout * 1000
   for (var minerId in connectedMiners) {
     var miner = connectedMiners[minerId]
@@ -79,6 +80,25 @@ setInterval(function () {
         delete bannedIPs[ip]
         delete perIPStats[ip]
         log('info', logSystem, 'Ban dropped for %s', [ip])
+      }
+    }
+  }
+
+  if (shareTrustEnabled){
+    var maxShareTrustAge = config.poolServer.shareTrust.maxAge
+    for (ip in minerShareTrust.ip) {
+      var minerShareTrustData = minerShareTrust.ip[ip]
+      if (dateNowSeconds - minerShareTrustData.lastShareSeconds > maxShareTrustAge){
+        delete minerShareTrust.ip[ip]
+        log('info', logSystem, 'ShareTrust data removed for ip %s', [ip])
+      }
+    }
+
+    for (address in minerShareTrust.address) {
+      var minerShareTrustData = minerShareTrust.address[address]
+      if (dateNowSeconds - minerShareTrustData.lastShareSeconds > maxShareTrustAge){
+        delete minerShareTrust.ip[address]
+        log('info', logSystem, 'ShareTrust data removed for address %s', [address])
       }
     }
   }
@@ -202,20 +222,32 @@ function Miner (id, login, workerName, pass, ip, startingDiff, noRetarget, pushM
   this.lastShareTime = Date.now() / 1000 | 0
 
   if (shareTrustEnabled) {
+    var dateNowSeconds = (Date.now() / 1000 | 0);
+    var shareTrustSettings = config.poolServer.shareTrust
     if (!minerShareTrust.ip[this.ip]) {
       minerShareTrust.ip[this.ip] = {
-      untrustedShareThreshold: config.poolServer.shareTrust.minUntrustedShares,
+      untrustedShareThreshold: shareTrustSettings.minUntrustedShares,
       trustProbability: 0,
-      minUntrustedSeconds: config.poolServer.shareTrust.minUntrustedSeconds,
-      trustBeginSeconds: (Date.now() / 1000 | 0)
+      minUntrustedSeconds: shareTrustSettings.minUntrustedSeconds,
+      trustBeginSeconds: dateNowSeconds,
+      currentPenaltyMultiplier: shareTrustSettings.minPenaltyMultiplier,
+      lastShareSeconds: dateNowSeconds,
+      penaltyStepUpBeginSeconds: dateNowSeconds,
+      penaltyStepDownBeginSeconds: dateNowSeconds,
+      probabilityStepWindowBeginSeconds: dateNowSeconds
       }
     }
     if (!minerShareTrust.address[this.login]) {
       minerShareTrust.address[this.login] = {
-      untrustedShareThreshold: config.poolServer.shareTrust.minUntrustedShares,
+      untrustedShareThreshold: shareTrustSettings.minUntrustedShares,
       trustProbability: 0,
-      minUntrustedSeconds: config.poolServer.shareTrust.minUntrustedSeconds,
-      trustBeginSeconds: (Date.now() / 1000 | 0)
+      minUntrustedSeconds: shareTrustSettings.minUntrustedSeconds,
+      trustBeginSeconds: dateNowSeconds,
+      currentPenaltyMultiplier: shareTrustSettings.minPenaltyMultiplier,
+      lastShareSeconds: dateNowSeconds,
+      penaltyStepUpBeginSeconds: dateNowSeconds,
+      penaltyStepDownBeginSeconds: dateNowSeconds,
+      probabilityStepWindowBeginSeconds: dateNowSeconds
       }
     }
   }
@@ -331,7 +363,7 @@ Miner.prototype = {
         log('warn', logSystem, 'Banned %s@%s', [this.login, this.ip])
         bannedIPs[this.ip] = Date.now()
         delete connectedMiners[this.id]
-        process.send({type: 'banIP', ip: this.ip})
+        process.send({ type: 'banIP', ip: this.ip })
       } else {
         stats.invalidShares = 0
         stats.validShares = 0
@@ -340,38 +372,73 @@ Miner.prototype = {
   },
   checkTrust: function (difficulty) {
     var dateNowSeconds = Date.now() / 1000 | 0
+    var shareTrustSettings = config.poolServer.shareTrust
     var shareTrustIP = minerShareTrust.ip[this.ip]
     var shareTrustAddress = minerShareTrust.address[this.login]
     if (shareTrustIP && shareTrustAddress) {
-      var ipPastThresholds = dateNowSeconds - shareTrustIP.trustBeginSeconds > config.poolServer.shareTrust.minUntrustedSeconds && shareTrustIP.untrustedShareThreshold <= 0
-      var addressPastThresholds = dateNowSeconds - shareTrustAddress.trustBeginSeconds > config.poolServer.shareTrust.minUntrustedSeconds && shareTrustAddress.untrustedShareThreshold <= 0
-      if (ipPastThresholds && addressPastThresholds && shareTrustIP.trustProbability >= shareTrustMaxTrustPercent && shareTrustAddress.trustProbability >= shareTrustMaxTrustPercent){
+      var ipPastThresholds = dateNowSeconds - shareTrustIP.trustBeginSeconds > shareTrustIP.minUntrustedSeconds && shareTrustIP.untrustedShareThreshold <= 0
+      var addressPastThresholds = dateNowSeconds - shareTrustAddress.trustBeginSeconds > shareTrustAddress.minUntrustedSeconds && shareTrustAddress.untrustedShareThreshold <= 0
+      var inShareWindow = dateNowSeconds - shareTrustAddress.lastShareSeconds < shareTrustSettings.maxShareWindow && dateNowSeconds - shareTrustIP.lastShareSeconds < shareTrustSettings.maxShareWindow
+      if (ipPastThresholds && addressPastThresholds && inShareWindow && shareTrustIP.trustProbability >= shareTrustMaxTrustPercent && shareTrustAddress.trustProbability >= shareTrustMaxTrustPercent) {
         this.trusted = true
       }
-      if ((difficulty < config.poolServer.shareTrust.maxTrustedDifficulty) && (ipPastThresholds && Math.random() < shareTrustIP.trustProbability) && (addressPastThresholds && Math.random() < shareTrustAddress.trustProbability)) {
+      if ((difficulty < shareTrustSettings.maxTrustedDifficulty) && (inShareWindow) && (ipPastThresholds && Math.random() < shareTrustIP.trustProbability) && (addressPastThresholds && Math.random() < shareTrustAddress.trustProbability)) {
         return true;
       }
     }
     return false;
   },
   setTrust: function (shareValidated) {
+    var dateNowSeconds = Date.now() / 1000 | 0
+    var shareTrustSettings = config.poolServer.shareTrust
     var shareTrustIP = minerShareTrust.ip[this.ip]
     var shareTrustAddress = minerShareTrust.address[this.login]
     if (shareTrustIP && shareTrustAddress) {
       if (shareValidated) {
-        shareTrustIP.trustProbability += shareTrustProbabilityStepPercent
+        if (dateNowSeconds - shareTrustAddress.lastShareSeconds >= shareTrustSettings.maxShareWindow || dateNowSeconds - shareTrustIP.lastShareSeconds >= shareTrustSettings.maxShareWindow) {
+          if (shareTrustIP.untrustedShareThreshold < shareTrustSettings.minUntrustedShares) { shareTrustIP.untrustedShareThreshold = shareTrustSettings.minUntrustedShares }
+          if (shareTrustAddress.untrustedShareThreshold < shareTrustSettings.minUntrustedShares) { shareTrustAddress.untrustedShareThreshold = shareTrustSettings.minUntrustedShares }
+          shareTrustAddress.trustBeginSeconds = shareTrustIP.trustBeginSeconds = dateNowSeconds
+          shareTrustIP.trustProbability = shareTrustAddress.trustProbability = 0
+        }
+        if (dateNowSeconds - shareTrustIP.probabilityStepWindowBeginSeconds > shareTrustSettings.probabilityStepWindow) {
+          shareTrustIP.trustProbability += shareTrustProbabilityStepPercent
+          shareTrustIP.probabilityStepWindowBeginSeconds = dateNowSeconds
+        }
+        if (dateNowSeconds - shareTrustAddress.probabilityStepWindowBeginSeconds > shareTrustSettings.probabilityStepWindow) {
+          shareTrustAddress.trustProbability += shareTrustProbabilityStepPercent
+          shareTrustAddress.probabilityStepWindowBeginSeconds = dateNowSeconds
+        }
+        if (shareTrustIP.currentPenaltyMultiplier > shareTrustSettings.minPenaltyMultiplier && dateNowSeconds - shareTrustIP.penaltyStepDownBeginSeconds > shareTrustSettings.penaltyStepDownWindow) {
+          shareTrustIP.currentPenaltyMultiplier -= shareTrustSettings.penaltyMultiplierStep
+          shareTrustIP.penaltyStepDownBeginSeconds = dateNowSeconds
+        }
+        if (shareTrustAddress.currentPenaltyMultiplier > shareTrustSettings.minPenaltyMultiplier && dateNowSeconds - shareTrustAddress.penaltyStepDownBeginSeconds > shareTrustSettings.penaltyStepDownWindow) {
+          shareTrustAddress.currentPenaltyMultiplier -= shareTrustSettings.penaltyMultiplierStep
+          shareTrustAddress.penaltyStepDownBeginSeconds = dateNowSeconds
+        }
         if (shareTrustIP.trustProbability > shareTrustMaxTrustPercent) { shareTrustIP.probability = shareTrustMaxTrustPercent }
-        if (shareTrustIP.untrustedShareThreshold > 0) { shareTrustIP.untrustedShareThreshold-- }
-        shareTrustAddress.trustProbability += shareTrustProbabilityStepPercent
         if (shareTrustAddress.trustProbability > shareTrustMaxTrustPercent) { shareTrustAddress.probability = shareTrustMaxTrustPercent }
+        if (shareTrustIP.untrustedShareThreshold > 0) { shareTrustIP.untrustedShareThreshold-- }
         if (shareTrustAddress.untrustedShareThreshold > 0) { shareTrustAddress.untrustedShareThreshold-- }
       } else {
         shareTrustIP.trustProbability = shareTrustAddress.trustProbability = 0
-        shareTrustAddress.untrustedShareThreshold = shareTrustIP.untrustedShareThreshold = (config.poolServer.shareTrust.minUntrustedShares * config.poolServer.shareTrust.penaltyMultiplier)
-        shareTrustAddress.trustBeginSeconds = shareTrustIP.trustBeginSeconds = (Date.now() / 1000 | 0)
-        shareTrustAddress.minUntrustedSeconds = shareTrustIP.minUntrustedSeconds = (config.poolServer.shareTrust.minUntrustedSeconds * config.poolServer.shareTrust.penaltyMultiplier)
+        shareTrustAddress.trustBeginSeconds = shareTrustIP.trustBeginSeconds = dateNowSeconds
+        if (shareTrustIP.currentPenaltyMultiplier < shareTrustSettings.maxPenaltyMultiplier && dateNowSeconds - shareTrustIP.penaltyStepUpBeginSeconds > shareTrustSettings.penaltyStepUpWindow) {
+          shareTrustIP.currentPenaltyMultiplier += shareTrustSettings.penaltyMultiplierStep
+          shareTrustIP.penaltyStepUpBeginSeconds = dateNowSeconds
+        }
+        if (shareTrustAddress.currentPenaltyMultiplier < shareTrustSettings.maxPenaltyMultiplier && dateNowSeconds - shareTrustAddress.penaltyStepUpBeginSeconds > shareTrustSettings.penaltyStepUpWindow) {
+          shareTrustAddress.currentPenaltyMultiplier += shareTrustSettings.penaltyMultiplierStep
+          shareTrustAddress.penaltyStepUpBeginSeconds = dateNowSeconds
+        }
+        shareTrustIP.untrustedShareThreshold = (shareTrustSettings.minUntrustedShares * shareTrustIP.currentPenaltyMultiplier)
+        shareTrustAddress.untrustedShareThreshold = (shareTrustSettings.minUntrustedShares * shareTrustAddress.currentPenaltyMultiplier)
+        shareTrustIP.minUntrustedSeconds = (shareTrustSettings.minUntrustedSeconds * shareTrustIP.currentPenaltyMultiplier)
+        shareTrustAddress.minUntrustedSeconds = (shareTrustSettings.minUntrustedSeconds * shareTrustAddress.currentPenaltyMultiplier)
         this.trusted = false
       }
+      shareTrustAddress.lastShareSeconds = shareTrustIP.lastShareSeconds = dateNowSeconds
     }
   }
 }


### PR DESCRIPTION
Continuation of previous PULL
This WIP provides persistent tracking of miner sharetrust probabilities, independently by both IP and Address. Both must validate for a share to be trusted. Probabilities are persisted in memory between miner reconnects.