### PR TITLE
Remove mixin/anonymity param from sendTransaction()

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ Explanation for each field:
     "enabled": true,
     "interval": 600, //how often to run in seconds
     "maxAddresses": 50, //split up payments if sending to more than this many addresses
-    "mixin": 3, //number of transactions yours is indistinguishable from
     "transferFee": 5000000000, //fee to pay for each transaction
     "minPayment": 100000000000, //miner balance required before sending payment
     "maxTransactionAmount": 0, //split transactions by this amount(to prevent "too big transaction" error)

--- a/config.json
+++ b/config.json
@@ -91,7 +91,6 @@
         "enabled": true,
         "interval": 120,
         "maxAddresses": 50,
-        "mixin": 7,
         "transferFee": 100,
         "minPayment": 100000,
         "maxTransactionAmount": 0,

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -87,7 +87,6 @@ function runInterval () {
             rpc: {
                         				transfers: [],
                         				fee: config.payments.transferFee,
-                       					anonymity: config.payments.mixin
             }
           }
         }
@@ -124,7 +123,6 @@ function runInterval () {
             txHash,
             transferCmd.amount,
             transferCmd.rpc.fee,
-            transferCmd.rpc.anonymity,
             Object.keys(transferCmd.rpc.transfers).length
           ].join(':')])
 
@@ -134,7 +132,6 @@ function runInterval () {
               txHash,
               destination.amount,
               transferCmd.rpc.fee,
-              transferCmd.rpc.anonymity
             ].join(':')])
           }
 


### PR DESCRIPTION
In preparation for the fork to 3 mixin, this removes the anonymity parameter in sendTransaction(), letting turtle-service determine it automatically, so payments can continue without manual intervention at the fork height.

I have not tested this, but the RPC bit should work fine. I'm not sure about the redis bit however, it looks like it's just logging strings, but not 100%.